### PR TITLE
Add descriptive subtitles to routing toggle settings

### DIFF
--- a/TurnBridge/GlobalSettingsView.swift
+++ b/TurnBridge/GlobalSettingsView.swift
@@ -24,29 +24,32 @@ struct GlobalSettingsView: View {
             }
 
             Section(header: Text("Routing")) {
-                VStack(alignment: .leading, spacing: 4) {
-                    Toggle("Allow LAN Access", isOn: $excludeLocalNetworks)
-                    Text("Access local network devices (printers, AirDrop, etc.) without routing through VPN")
-                        .font(.caption)
-                        .foregroundColor(.secondary)
+                Toggle(isOn: $excludeLocalNetworks) {
+                    VStack(alignment: .leading) {
+                        Text("Allow LAN Access")
+                        Text("Access local network devices without routing through VPN")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
                 }
-                .padding(.vertical, 2)
 
-                VStack(alignment: .leading, spacing: 4) {
-                    Toggle("Bypass APNs", isOn: $excludeAPNs)
-                    Text("Send Apple Push Notifications directly, bypassing the VPN tunnel")
-                        .font(.caption)
-                        .foregroundColor(.secondary)
+                Toggle(isOn: $excludeAPNs) {
+                    VStack(alignment: .leading) {
+                        Text("Bypass APNs")
+                        Text("Send push notifications directly, bypassing the tunnel")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
                 }
-                .padding(.vertical, 2)
 
-                VStack(alignment: .leading, spacing: 4) {
-                    Toggle("Bypass Cellular", isOn: $excludeCellularServices)
-                    Text("Exclude voice calls, SMS, and Visual Voicemail from the VPN tunnel")
-                        .font(.caption)
-                        .foregroundColor(.secondary)
+                Toggle(isOn: $excludeCellularServices) {
+                    VStack(alignment: .leading) {
+                        Text("Bypass Cellular")
+                        Text("Exclude calls, SMS, and voicemail from the tunnel")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
                 }
-                .padding(.vertical, 2)
             }
         }
         .navigationTitle("Settings")

--- a/TurnBridge/GlobalSettingsView.swift
+++ b/TurnBridge/GlobalSettingsView.swift
@@ -24,9 +24,29 @@ struct GlobalSettingsView: View {
             }
 
             Section(header: Text("Routing")) {
-                Toggle("Allow LAN Access", isOn: $excludeLocalNetworks)
-                Toggle("Bypass APNs", isOn: $excludeAPNs)
-                Toggle("Bypass Cellular", isOn: $excludeCellularServices)
+                VStack(alignment: .leading, spacing: 4) {
+                    Toggle("Allow LAN Access", isOn: $excludeLocalNetworks)
+                    Text("Access local network devices (printers, AirDrop, etc.) without routing through VPN")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+                .padding(.vertical, 2)
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Toggle("Bypass APNs", isOn: $excludeAPNs)
+                    Text("Send Apple Push Notifications directly, bypassing the VPN tunnel")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+                .padding(.vertical, 2)
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Toggle("Bypass Cellular", isOn: $excludeCellularServices)
+                    Text("Exclude voice calls, SMS, and Visual Voicemail from the VPN tunnel")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+                .padding(.vertical, 2)
             }
         }
         .navigationTitle("Settings")


### PR DESCRIPTION
Adds brief explanatory subtitles below each toggle in the Routing section of Global Settings, so users understand what each option does without guessing.

- **Allow LAN Access** — Access local network devices (printers, AirDrop, etc.) without routing through VPN
- **Bypass APNs** — Send Apple Push Notifications directly, bypassing the VPN tunnel
- **Bypass Cellular** — Exclude voice calls, SMS, and Visual Voicemail from the VPN tunnel

Minimal change, one file only.